### PR TITLE
feat: add case-studies page with scroll reveal animation system

### DIFF
--- a/apps/frontend/src/components/cta-section/index.astro
+++ b/apps/frontend/src/components/cta-section/index.astro
@@ -1,0 +1,127 @@
+<section class="cta-section" aria-label="Call to action">
+    <div class="cta-section__inner">
+        <h2 class="cta-section__heading" data-animate data-animate-delay="1">
+            Building something ambitious?
+            <span class="cta-section__accent">Let's architect it right</span>
+            from day one.
+        </h2>
+
+        <p class="cta-section__subtext" data-animate data-animate-delay="2">
+            I help startups and growing teams design scalable systems from the ground up.
+        </p>
+
+        <a href="/schedule" class="cta-section__btn" data-animate data-animate-delay="3">
+            Book a Strategy Call
+        </a>
+    </div>
+</section>
+
+<style>
+    @import "../../styles/mixins.css";
+
+    .cta-section {
+        position: relative;
+        z-index: 1;
+        padding-block: 5rem 6rem;
+    }
+
+    .cta-section__inner {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding-inline: 1rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 1.5rem;
+    }
+
+    .cta-section__heading {
+        font-size: clamp(1.9rem, 8vw, 3rem);
+        font-weight: 760;
+        letter-spacing: -0.04em;
+        line-height: 1.1;
+        color: var(--color-text-primary);
+        text-wrap: balance;
+        max-width: 18ch;
+    }
+
+    .cta-section__accent {
+        color: var(--color-accent);
+    }
+
+    .cta-section__subtext {
+        color: var(--color-text-secondary);
+        font-size: clamp(0.95rem, 2.5vw, 1.05rem);
+        line-height: 1.65;
+        max-width: 42ch;
+        text-wrap: pretty;
+    }
+
+    .cta-section__btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-top: 0.5rem;
+        padding: 0.95rem 2rem;
+        min-height: 3.9rem;
+        border-radius: 0.95rem;
+        border: 1px solid transparent;
+        color: #04131f;
+        background: linear-gradient(135deg, #44b7ff 0%, #38bdf8 52%, #3cb4ff 100%);
+        box-shadow:
+            0 12px 30px rgba(56, 189, 248, 0.25),
+            inset 0 -1px 0 rgba(255, 255, 255, 0.25);
+        font-size: 1.03rem;
+        font-weight: 650;
+        letter-spacing: -0.01em;
+        text-decoration: none;
+        transition:
+            transform var(--transition-fast),
+            box-shadow var(--transition-base);
+        will-change: transform;
+    }
+
+    .cta-section__btn:hover {
+        transform: translateY(-2px);
+        box-shadow:
+            0 15px 34px rgba(56, 189, 248, 0.35),
+            inset 0 -1px 0 rgba(255, 255, 255, 0.3);
+    }
+
+    .cta-section__btn:focus-visible {
+        outline: 2px solid rgba(56, 189, 248, 0.95);
+        outline-offset: 2px;
+    }
+
+    .cta-section__btn:active {
+        transform: translateY(0);
+    }
+
+    @mixin tablet-up {
+        .cta-section__inner {
+            padding-inline: 1.5rem;
+        }
+
+        .cta-section__heading {
+            font-size: clamp(2.2rem, 5vw, 3rem);
+        }
+
+        .cta-section__btn {
+            min-height: 3.7rem;
+            border-radius: 0.85rem;
+            font-size: 1.05rem;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .cta-section__btn {
+            transition: none;
+        }
+    }
+</style>
+
+<script>
+    import { initScrollReveal } from "@/utils/animations";
+    initScrollReveal();
+</script>

--- a/apps/frontend/src/modules/case-studies/case-study-card.astro
+++ b/apps/frontend/src/modules/case-studies/case-study-card.astro
@@ -1,0 +1,330 @@
+---
+export interface Props {
+    title: string;
+    description: string;
+    tags: string[];
+    bullets: string[];
+    tech: string[];
+    href?: string;
+    sourceHref?: string;
+    liveHref?: string;
+    image?: string;
+    [key: string]: unknown;
+}
+
+const {
+    title,
+    description,
+    tags,
+    bullets,
+    href = "#",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    sourceHref: _sourceHref = "#",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    liveHref: _liveHref = "#",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    tech: _tech,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    image: _image,
+    ...rest
+} = Astro.props;
+---
+
+<a class="csc-card" href={href} aria-label={`View case study: ${title}`} {...rest}>
+    <!-- Image placeholder -->
+    <div class="csc-card__image" aria-hidden="true">
+        <div class="csc-card__image-inner"></div>
+        <div class="csc-card__image-overlay"></div>
+    </div>
+
+    <!-- Content -->
+    <div class="csc-card__body">
+        <!-- Tech tags -->
+        <div class="csc-card__tags">
+            {tags.map((tag) => <span class="csc-card__tag">{tag}</span>)}
+        </div>
+
+        <!-- Title -->
+        <h3 class="csc-card__title">{title}</h3>
+
+        <!-- Description -->
+        <p class="csc-card__desc">{description}</p>
+
+        <!-- Bullet points -->
+        <ul class="csc-card__bullets" role="list">
+            {
+                bullets.map((b) => (
+                    <li class="csc-card__bullet">
+                        <svg
+                            class="csc-card__bullet-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                        >
+                            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                            <polyline points="22 4 12 14.01 9 11.01" />
+                        </svg>
+                        {b}
+                    </li>
+                ))
+            }
+        </ul>
+    </div>
+
+    <!-- Footer -->
+    <div class="csc-card__footer">
+        <div class="csc-card__footer-links">
+            <span class="csc-card__footer-link" aria-label="Source code">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                >
+                    <polyline points="16 18 22 12 16 6"></polyline>
+                    <polyline points="8 6 2 12 8 18"></polyline>
+                </svg>
+                SOURCE CODE
+            </span>
+            <span class="csc-card__footer-link" aria-label="Live project">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                >
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                    <polyline points="15 3 21 3 21 9"></polyline>
+                    <line x1="10" y1="14" x2="21" y2="3"></line>
+                </svg>
+                LIVE PROJECT
+            </span>
+        </div>
+    </div>
+</a>
+
+<style>
+    @import "../../styles/mixins.css";
+
+    /* ── Card shell ── */
+    .csc-card {
+        display: flex;
+        flex-direction: column;
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 0.875rem;
+        overflow: hidden;
+        text-decoration: none;
+        color: inherit;
+        transition:
+            border-color var(--transition-fast),
+            transform var(--transition-fast),
+            box-shadow var(--transition-base);
+        will-change: transform;
+        cursor: pointer;
+    }
+
+    .csc-card:hover {
+        border-color: rgba(56, 189, 248, 0.3);
+        transform: translateY(-3px);
+        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+    }
+
+    .csc-card:focus-visible {
+        outline: 2px solid rgba(56, 189, 248, 0.9);
+        outline-offset: 2px;
+    }
+
+    .csc-card:active {
+        transform: translateY(-1px);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .csc-card {
+            transition: border-color var(--transition-fast);
+        }
+        .csc-card:hover {
+            transform: none;
+        }
+    }
+
+    /* ── Image area ── */
+    .csc-card__image {
+        position: relative;
+        height: 200px;
+        overflow: hidden;
+        flex-shrink: 0;
+    }
+
+    @mixin tablet-up {
+        .csc-card__image {
+            height: 220px;
+        }
+    }
+
+    .csc-card__image-inner {
+        width: 100%;
+        height: 100%;
+        background:
+            radial-gradient(ellipse at 30% 40%, rgba(56, 189, 248, 0.18) 0%, transparent 60%),
+            radial-gradient(ellipse at 75% 65%, rgba(14, 165, 233, 0.12) 0%, transparent 55%),
+            linear-gradient(160deg, #0a1628 0%, #071020 40%, #050d1a 100%);
+    }
+
+    /* Subtle circuit-board grid pattern overlay */
+    .csc-card__image-inner::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image:
+            linear-gradient(rgba(56, 189, 248, 0.06) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(56, 189, 248, 0.06) 1px, transparent 1px);
+        background-size: 32px 32px;
+    }
+
+    /* Glowing node dots */
+    .csc-card__image-inner::after {
+        content: "";
+        position: absolute;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: rgba(56, 189, 248, 0.7);
+        box-shadow: 0 0 12px 4px rgba(56, 189, 248, 0.35);
+        top: 38%;
+        left: 28%;
+    }
+
+    /* Gradient fade at bottom so content blends in */
+    .csc-card__image-overlay {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(to bottom, transparent 50%, var(--color-surface) 100%);
+        pointer-events: none;
+    }
+
+    /* ── Body ── */
+    .csc-card__body {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1.75rem 1.75rem 1.5rem;
+        flex: 1;
+    }
+
+    /* ── Tags ── */
+    .csc-card__tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-bottom: 0.7rem;
+    }
+
+    .csc-card__tag {
+        display: inline-block;
+        font-size: 0.65rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        padding: 0.2rem 0.55rem;
+        border-radius: 0.3rem;
+        border: 1px solid rgba(56, 189, 248, 0.25);
+        background: rgba(56, 189, 248, 0.08);
+        color: var(--color-accent);
+    }
+
+    /* ── Title ── */
+    .csc-card__title {
+        font-size: clamp(1.1rem, 3vw, 1.3rem);
+        font-weight: 700;
+        color: var(--color-text-primary);
+        letter-spacing: -0.03em;
+        line-height: 1.2;
+        margin: 0;
+    }
+
+    /* ── Description ── */
+    .csc-card__desc {
+        font-size: 0.875rem;
+        color: var(--color-text-secondary);
+        line-height: 1.65;
+        margin: 0;
+    }
+
+    /* ── Bullets ── */
+    .csc-card__bullets {
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+        margin: 0;
+        padding: 0;
+    }
+
+    .csc-card__bullet {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.5rem;
+        font-size: 0.84rem;
+        color: var(--color-text-secondary);
+        line-height: 1.5;
+    }
+
+    .csc-card__bullet-icon {
+        color: var(--color-accent);
+        flex-shrink: 0;
+        margin-top: 0.15rem;
+    }
+
+    /* ── Footer ── */
+    .csc-card__footer {
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 0.75rem;
+        padding: 1.25rem 1.75rem;
+        border-top: 1px solid var(--color-border);
+        flex-wrap: wrap;
+    }
+
+    .csc-card__footer-links {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .csc-card__footer-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.7rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        color: var(--color-text-secondary);
+        transition: color var(--transition-fast);
+        text-transform: uppercase;
+    }
+
+    .csc-card:hover .csc-card__footer-link {
+        color: var(--color-text-primary);
+    }
+</style>

--- a/apps/frontend/src/modules/case-studies/index.astro
+++ b/apps/frontend/src/modules/case-studies/index.astro
@@ -1,0 +1,179 @@
+---
+import CaseStudyCard from "./case-study-card.astro";
+
+const projects = [
+    {
+        title: "Neural Grid Orchestrator",
+        description:
+            "A high-throughput distributed system designed for real-time processing of sensory data across edge computing nodes.",
+        tags: ["REACT", "AWS LAMBDA", "TERRAFORM"],
+        bullets: [
+            "Improved latency by 40% across regional clusters.",
+            "Automated CI/CD deployment pipeline for 200+ services.",
+        ],
+        tech: ["React", "AWS Lambda", "Terraform"],
+        href: "#",
+        sourceHref: "#",
+        liveHref: "#",
+    },
+    {
+        title: "Vortex Data Integrity",
+        description:
+            "Secure vault infrastructure providing cryptographic verification for financial transaction ledgers and audit trails.",
+        tags: ["NEXT.JS", "POSTGRESQL", "REDIS"],
+        bullets: [
+            "Zero downtime during migration of 50TB legacy data.",
+            "Implemented SOC2 compliant monitoring systems.",
+        ],
+        tech: ["Next.js", "PostgreSQL", "Redis"],
+        href: "#",
+        sourceHref: "#",
+        liveHref: "#",
+    },
+    {
+        title: "Prism API Gateway",
+        description:
+            "Unified entry point for microservices ecosystem handling over 1M requests per minute with intelligent caching.",
+        tags: ["NODE.JS", "GRAPHQL", "DOCKER"],
+        bullets: [
+            "Reduced API overhead by 65% using GraphQL schema stitching.",
+            "Auto-scaling infrastructure for peak demand handling.",
+        ],
+        tech: ["Node.js", "GraphQL", "Docker"],
+        href: "#",
+        sourceHref: "#",
+        liveHref: "#",
+    },
+    {
+        title: "Obsidian Core Engine",
+        description:
+            "Low-level computational kernel developed for ultra-fast physics simulations within browser environments.",
+        tags: ["RUST", "WEBASSEMBLY", "KUBERNETES"],
+        bullets: [
+            "Performance parity with native C++ applications.",
+            "Containerized deployment with zero-config clustering.",
+        ],
+        tech: ["Rust", "WebAssembly", "Kubernetes"],
+        href: "#",
+        sourceHref: "#",
+        liveHref: "#",
+    },
+];
+---
+
+<section class="csw-section" aria-labelledby="csw-heading">
+    <div class="csw-section__inner">
+        <!-- Page header -->
+        <header class="csw-section__header" data-animate>
+            <p class="csw-section__label">
+                <span class="csw-section__label-dot" aria-hidden="true"></span>
+                ARCHIVE REGISTRY
+            </p>
+            <h1 class="csw-section__heading" id="csw-heading">Selected Work</h1>
+            <p class="csw-section__subheading">
+                A selection of systems I've designed and built, focused on scalability, performance,
+                and real-world impact.
+            </p>
+        </header>
+
+        <!-- 2-column grid of cards -->
+        <div class="csw-section__grid">
+            {
+                projects.map((project, i) => (
+                    <CaseStudyCard {...project} data-animate data-animate-delay={String(i + 1)} />
+                ))
+            }
+        </div>
+    </div>
+</section>
+
+<style>
+    @import "../../styles/mixins.css";
+
+    .csw-section {
+        position: relative;
+        z-index: 1;
+        padding-block: 4rem 2rem;
+    }
+
+    .csw-section__inner {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding-inline: 1rem;
+    }
+
+    @mixin tablet-up {
+        .csw-section__inner {
+            padding-inline: 1.5rem;
+        }
+    }
+
+    /* ── Page header ── */
+    .csw-section__header {
+        margin-bottom: 3rem;
+    }
+
+    @mixin tablet-up {
+        .csw-section__header {
+            margin-bottom: 3.5rem;
+        }
+    }
+
+    .csw-section__label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-accent);
+        margin-bottom: 0.85rem;
+    }
+
+    .csw-section__label-dot {
+        display: inline-block;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--color-accent);
+        box-shadow: 0 0 6px 2px rgba(56, 189, 248, 0.5);
+        flex-shrink: 0;
+    }
+
+    .csw-section__heading {
+        font-size: clamp(2.25rem, 8vw, 3.5rem);
+        font-weight: 780;
+        letter-spacing: -0.04em;
+        line-height: 1.05;
+        color: var(--color-text-primary);
+        margin-bottom: 0.85rem;
+    }
+
+    .csw-section__subheading {
+        font-size: clamp(0.9rem, 2.5vw, 1rem);
+        color: var(--color-text-secondary);
+        line-height: 1.65;
+        max-width: 52ch;
+        text-wrap: pretty;
+    }
+
+    /* ── Grid ── */
+    .csw-section__grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1.25rem;
+    }
+
+    @mixin tablet-up {
+        .csw-section__grid {
+            grid-template-columns: repeat(2, 1fr);
+            gap: 1.5rem;
+        }
+    }
+</style>
+
+<script>
+    import { initScrollReveal } from "@/utils/animations";
+    initScrollReveal();
+</script>

--- a/apps/frontend/src/pages/case-studies.astro
+++ b/apps/frontend/src/pages/case-studies.astro
@@ -1,0 +1,10 @@
+---
+import Layout from "@/layouts/layout/index.astro";
+import CaseStudiesModule from "@/modules/case-studies/index.astro";
+import CtaSection from "@/components/cta-section/index.astro";
+---
+
+<Layout title="Selected Work – Eduardo Varela">
+    <CaseStudiesModule />
+    <CtaSection />
+</Layout>

--- a/apps/frontend/src/styles/animations.css
+++ b/apps/frontend/src/styles/animations.css
@@ -1,0 +1,50 @@
+/* ==========================================================================
+   Scroll Reveal Animations
+   --------------------------------------------------------------------------
+   Elements opt in by adding the `data-animate` attribute.
+   The IntersectionObserver in src/utils/animations.ts adds `.is-visible`
+   when the element enters the viewport, triggering the transition.
+
+   Stagger delays are controlled via `data-animate-delay="N"` (N = 1, 2, 3…).
+   Each step = 80ms, set as --reveal-delay by the JS utility.
+   ========================================================================== */
+
+/* ── Keyframe (used as a reference — actual reveal is transition-based) ── */
+@keyframes reveal-fade-up {
+    from {
+        opacity: 0;
+        transform: translateY(18px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* ── Hidden state: applied to all opted-in elements before they enter view ── */
+[data-animate] {
+    opacity: 0;
+    transform: translateY(28px);
+    transition:
+        opacity 700ms cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0ms),
+        transform 700ms cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0ms);
+    /* Avoid layout thrash on elements that will animate */
+    will-change: opacity, transform;
+}
+
+/* ── Visible state: added by IntersectionObserver ── */
+[data-animate].is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* ── Reduced motion: skip entirely, show elements immediately ── */
+@media (prefers-reduced-motion: reduce) {
+    [data-animate] {
+        opacity: 1;
+        transform: none;
+        transition: none;
+        will-change: auto;
+    }
+}

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "./mixins.css";
+@import "./animations.css";
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
 /* ===== CSS Custom Properties ===== */

--- a/apps/frontend/src/utils/animations.ts
+++ b/apps/frontend/src/utils/animations.ts
@@ -1,0 +1,45 @@
+/**
+ * Scroll reveal utility using a single shared IntersectionObserver.
+ *
+ * Usage:
+ *   1. Add `data-animate` to any element you want to animate on scroll.
+ *   2. Optionally add `data-animate-delay="N"` (N = 1, 2, 3 …) for staggered
+ *      entrance — each step adds 120ms of delay.
+ *   3. Call `initScrollReveal()` once in a `<script>` tag on the page or
+ *      inside any component — it is safe to call multiple times per page,
+ *      subsequent calls are no-ops.
+ *
+ * The CSS states (hidden / visible) live in src/styles/animations.css.
+ */
+
+const STAGGER_STEP_MS = 120;
+
+let initialized = false;
+
+export function initScrollReveal(): void {
+    if (initialized) return;
+    initialized = true;
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            for (const entry of entries) {
+                if (!entry.isIntersecting) continue;
+
+                const el = entry.target as HTMLElement;
+
+                // Compute stagger delay from data-animate-delay="N"
+                const step = Number(el.dataset.animateDelay ?? 0);
+                if (step > 0) {
+                    el.style.setProperty("--reveal-delay", `${step * STAGGER_STEP_MS}ms`);
+                }
+
+                el.classList.add("is-visible");
+                observer.unobserve(el);
+            }
+        },
+        // Fire when ~12% of the element is inside the viewport
+        { threshold: 0.12 },
+    );
+
+    document.querySelectorAll<HTMLElement>("[data-animate]").forEach((el) => observer.observe(el));
+}


### PR DESCRIPTION
- Add case-studies page with 2-column card grid
- Add reusable scroll reveal utility (IntersectionObserver) in src/utils/animations.ts
- Add animations.css with expo-out transition (700ms, cubic-bezier(0.22,1,0.36,1))
- Add staggered entrance per card via data-animate-delay
- Add CtaSection shared component with self-contained scroll reveal
- Import animations.css globally via global.css